### PR TITLE
update to 0.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - matplotlib-base >=3.2
-    - numpy {{ pin_compatible('numpy') }}
+    - numpy >=1.20.0
     - scipy >=1.8.0
     - pandas >=1.3.0
     - xarray >=0.21.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 981cce0282bdf6f3b379255b95a440979f9a0ef0ae9dd88a54f763cf5b31484c
 build:
-  noarch: python
   number: 0
   # skipping 3.8 because of missing xarray-einstats for 3.8
   skip: True  # [py==3.8]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - scipy >=1.8.0
     - pandas >=1.3.0
     - xarray >=0.21.0
-    - netcdf4 >=1.0.2
+    - netcdf4
+    - h5netcdf >=1.0.2
     - packaging
     - typing_extensions >=4.1.0
     - xarray-einstats >=0.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 build:
   noarch: python
   number: 0
+  # skipping 3.8 because of missing xarray-einstats for 3.8
+  skip: True  # [py==3.8]
   skip: True  # [py<=2.7]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,12 @@ requirements:
     - python
     - matplotlib-base >=3.2
     - numpy {{ numpy }}
-    - scipy
-    - pandas
-    - xarray
-    - netcdf4
+    - scipy >=1.8.0
+    - pandas >=1.3.0
+    - xarray >=0.21.0
+    - netcdf4 >=1.0.2
     - packaging
-    - typing_extensions
+    - typing_extensions >=4.1.0
     - xarray-einstats >=0.3
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.15.1" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 981cce0282bdf6f3b379255b95a440979f9a0ef0ae9dd88a54f763cf5b31484c
+  sha256: b05d790901dd5eaafe02d8a8f3780003f585dbdffaefacb904a162143fb1e95e
 build:
   number: 0
   skip: True  # [py<39]
@@ -17,12 +17,12 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=60.0.0
     - wheel
   run:
     - python
     - matplotlib-base >=3.2
-    - numpy >=1.20.0
+    - numpy >=1.21.0
     - scipy >=1.8.0
     - pandas >=1.3.0
     - xarray >=0.21.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - wheel
   run:
+    - python
     - matplotlib-base >=3.2
     - numpy >=1.20.0
     - scipy >=1.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,8 @@ source:
   sha256: 981cce0282bdf6f3b379255b95a440979f9a0ef0ae9dd88a54f763cf5b31484c
 build:
   number: 0
-  # skipping 3.8 because of missing xarray-einstats for 3.8
   skip: True  # [py<39]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   # skipping 3.8 because of missing xarray-einstats for 3.8
-  skip: True  # [py<=2.7]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.11.2" %}
+{% set version = "0.15.1" %}
 
 package:
   name: {{ name|lower }}
@@ -11,21 +11,25 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<=2.7]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3
+    - python
     - pip
+    - setuptools
   run:
-    - python >=3
-    - matplotlib-base >=3.0
-    - numpy
+    - python
+    - matplotlib-base >=3.2
+    - numpy {{ numpy }}
     - scipy
     - pandas
     - xarray
     - netcdf4
     - packaging
+    - typing_extensions
+    - xarray-einstats >=0.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a9d0eb32e84a0472aa78a488ba9b12b05e7be8c2c8fb34a1ba6286cc1254ee0d
+  sha256: 981cce0282bdf6f3b379255b95a440979f9a0ef0ae9dd88a54f763cf5b31484c
 build:
   noarch: python
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - wheels
+    - wheel
   run:
     - matplotlib-base >=3.2
     - numpy {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheels
   run:
-    - python
     - matplotlib-base >=3.2
-    - numpy {{ numpy }}
+    - numpy {{ pin_compatible('numpy') }}
     - scipy >=1.8.0
     - pandas >=1.3.0
     - xarray >=0.21.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,10 @@ requirements:
 test:
   imports:
     - arviz
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - scipy >=1.8.0
     - pandas >=1.3.0
     - xarray >=0.21.0
-    - netcdf4
     - h5netcdf >=1.0.2
     - packaging
     - typing_extensions >=4.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 0
   # skipping 3.8 because of missing xarray-einstats for 3.8
-  skip: True  # [py==3.8]
   skip: True  # [py<=2.7]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
* [x] checked license
* [x] updated dependencies with [upstream](https://github.com/arviz-devs/arviz/blob/main/requirements.txt)
* [x] updated about section

This version of `arviz` makes use of one of two possible packages that are similar implementations of the same api:
* `h5netcdf`
* `netcdf4`

while in the past `netcdf4` has been preferred, in this iteration `h5netcdf` is set as the default backing implementation.
This results in dropping `netcdf4` as one of the dependencies (which is in fact also not referenced by the [upstream requirements](https://github.com/arviz-devs/arviz/blob/main/requirements.txt)). While supporting both may expand the number of supported platforms, `h5netcdf` allows to build all that `netcdf4` does and then some. Hence `netcdf4` has been dropped.