### PR TITLE
[PKG-4323] Update to 0.17.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" --ignore="arviz/tests/base_tests/test_plots_bokeh.py" --ignore="arviz/tests/base_tests/test_plots_matplotlib.py -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" --ignore="arviz/tests/base_tests/test_plots_bokeh.py" --ignore="arviz/tests/base_tests/test_plots_matplotlib.py" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ test:
     - bokeh >=1.4.0
   commands:
     - pip check
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win or (win and py>39)]
-    #- pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" --ignore="arviz/tests/base_tests/test_plots_bokeh.py" --ignore="arviz/tests/base_tests/test_plots_matplotlib.py -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin)"  # [win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.16.0" %}
+{% set version = "0.17.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,8 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b05d790901dd5eaafe02d8a8f3780003f585dbdffaefacb904a162143fb1e95e
+  sha256: b46dc693e34fd3dff20d824234c7a01cb04b1b536441e285218c54fab42c3c09
+
 build:
   number: 0
   skip: True  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,14 +42,10 @@ test:
     - pytest
     - pytest-cov
     - cloudpickle
-    - numba  # [not s390x]
-    - netcdf4  # [not s390x]
     - bokeh >=1.4.0
     - contourpy
     - ujson
     - dask
-    - zarr >=2.5.0  # [not s390x]
-    - xarray
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,20 +33,19 @@ requirements:
     - xarray-einstats >=0.3
 
 test:
-  source_files:
-    - arviz
+  source_files:  # [not win]
+    - arviz      # [not win]
   imports:
     - arviz
   requires:
     - pip
-    - pytest
-    - pytest-cov
-    - cloudpickle
-    - bokeh >=1.4.0
+    - pytest        # [not win]
+    - pytest-cov    # [not win]
+    - cloudpickle   # [not win]
+    - bokeh >=1.4.0 # [not win]
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - wheel
   run:
     - python
-    - matplotlib-base >=3.2
-    - numpy >=1.21.0
+    - matplotlib-base >=3.5
+    - numpy >=1.22.0,<2.0
     - scipy >=1.8.0
-    - pandas >=1.3.0
+    - pandas >=1.4.0
     - xarray >=0.21.0
     - h5netcdf >=1.0.2
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,26 @@ requirements:
     - xarray-einstats >=0.3
 
 test:
+  source_files:
+    - arviz
   imports:
     - arviz
   requires:
     - pip
+    - pytest
+    - pytest-cov
+    - cloudpickle
+    - numba
+    - netcdf4
+    - bokeh >=1.4.0
+    - contourpy
+    - ujson
+    - dask
+    - zarr >=2.5.0
+    - xarray
   commands:
     - pip check
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,13 +43,10 @@ test:
     - pytest-cov
     - cloudpickle
     - bokeh >=1.4.0
-    #- contourpy
-    #- ujson
-    #- dask
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims)"  # [win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,13 +42,13 @@ test:
     - pytest
     - pytest-cov
     - cloudpickle
-    - numba
-    - netcdf4
+    - numba  # [not s390x]
+    - netcdf4  # [not s390x]
     - bokeh >=1.4.0
     - contourpy
     - ujson
     - dask
-    - zarr >=2.5.0
+    - zarr >=2.5.0  # [not s390x]
     - xarray
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,19 +33,20 @@ requirements:
     - xarray-einstats >=0.3
 
 test:
-  source_files:  # [not win]
-    - arviz      # [not win]
+  source_files:
+    - arviz
   imports:
     - arviz
   requires:
     - pip
-    - pytest        # [not win]
-    - pytest-cov    # [not win]
-    - cloudpickle   # [not win]
-    - bokeh >=1.4.0 # [not win]
+    - pytest
+    - pytest-cov
+    - cloudpickle
+    - bokeh >=1.4.0
   commands:
     - pip check
     - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ test:
     - bokeh >=1.4.0
   commands:
     - pip check
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win or (win and py>39)]
+    #- pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,12 +43,13 @@ test:
     - pytest-cov
     - cloudpickle
     - bokeh >=1.4.0
-    - contourpy
-    - ujson
-    - dask
+    #- contourpy
+    #- ujson
+    #- dask
   commands:
     - pip check
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims)"  # [win]
 
 about:
   home: https://github.com/arviz-devs/arviz


### PR DESCRIPTION
arviz 0.17.1

**Destination channel:** defaults

### Links

- [PKG-4323](https://anaconda.atlassian.net/browse/PKG-4323) 
- [Upstream repository](https://github.com/arviz-devs/arviz)
- [Upstream changelog/diff](https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0171-2024-mar-13)

### Explanation of changes:

- Added upstream tests
- Skipped several tests that were failing due to a missing file in `arviz/tests/saved_models`
- `win-64` tests failing, see comment below. If necessary, we can likely skip upstream tests.
- Ongoing http error with OSX builders, but builds have been successful in previous commits.


[PKG-4323]: https://anaconda.atlassian.net/browse/PKG-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ