### PR TITLE
arviz 0.21.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.17.1" %}
+{% set version = "0.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b46dc693e34fd3dff20d824234c7a01cb04b1b536441e285218c54fab42c3c09
+  sha256: ad5c99b998b750e585bdd1f3ba11e3f8729e01d06dc7fdc251450039e88cfd71
 
 build:
   number: 0
-  skip: True  # [py<39]
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -23,14 +23,20 @@ requirements:
   run:
     - python
     - matplotlib-base >=3.5
-    - numpy >=1.22.0,<2.0
-    - scipy >=1.8.0
-    - pandas >=1.4.0
-    - xarray >=0.21.0
+    - numpy >=1.23.0
+    - scipy >=1.9.0
+    - pandas >=1.5.0
+    - xarray >=2022.6.0
     - h5netcdf >=1.0.2
     - packaging
     - typing_extensions >=4.1.0
+    - setuptools >=60.0.0
+    - typing-extensions >=4.1.0
     - xarray-einstats >=0.3
+  run_constrained:
+    - bokeh >=3 # extra:all
+    - zarr >=2.5.0,<3 # extra:all
+    - dm-tree >=0.1.8 # extra:all
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ test:
     - bokeh >=1.4.0
   commands:
     - pip check
-    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file)"  # [not win]
+    - pytest arviz/tests --ignore="arviz/tests/external_tests" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_trace_legend or test_plot_ppc_transposed)"  # [not win]
     - pytest arviz/tests --ignore="arviz/tests/external_tests" --ignore="arviz/tests/base_tests/test_plots_bokeh.py" --ignore="arviz/tests/base_tests/test_plots_matplotlib.py" -k "not (test_io_function or test_io_method or test_warning_rc_file or test_bad_rc_file or test_deterministic or test_empty_inference_data_object or test_rctemplate_updated or test_rc_context_file or test_plot_forest_single_value or test_plot_density_discrete_combinedims or test_plot_violin or test_plot_density_float)"  # [win]
 
 about:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7411](https://anaconda.atlassian.net/browse/PKG-7411)
- [Upstream repo](https://github.com/arviz-devs/arviz/tree/v0.21.0)
- release-diff: https://github.com/arviz-devs/arviz/compare/v0.17.1...v0.21.0
- changelog: https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md
- license: https://github.com/arviz-devs/arviz/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/arviz-devs/arviz/blob/v0.21.0/requirements-test.txt
  - https://github.com/arviz-devs/arviz/blob/v0.21.0/requirements.txt
  - https://github.com/arviz-devs/arviz/blob/v0.21.0/setup.py


### Explanation of changes:

- Skip py<310
- Update runtime dependencies
- Add run_constrained for optional dependencies
- Skip two more tests on Unix: test_plot_trace_legend, test_plot_ppc_transposed


[PKG-7411]: https://anaconda.atlassian.net/browse/PKG-7411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ