### PR TITLE
v0.23.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - numpy >=1.26.0
     - scipy >=1.11.0
     - packaging
+    - setuptools
     - pandas >=2.1.0
     - xarray >=2023.7.0
     - h5netcdf >=1.0.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.22.0" %}
+{% set version = "0.23.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d9df7592f1ce77ce69f7504dba13f8d550204c49c23e54849861dbcb2c640954
+  sha256: 611be826995066036c9443ea98d11486c279ef3da3b6cdc5c0816fab434115b9
 
 build:
   number: 0
@@ -29,8 +29,10 @@ requirements:
     - pandas >=2.1.0
     - xarray >=2023.7.0
     - h5netcdf >=1.0.2
+    - h5py
     - typing_extensions >=4.1.0
     - xarray-einstats >=0.3
+    - platformdirs
   run_constrained:
     - bokeh >=3
     - zarr >=2.5.0,<3


### PR DESCRIPTION
arviz v0.23.4

**Destination channel:** defaults

### Links

- [PKG-13781](https://anaconda.atlassian.net/browse/PKG-13781) 
- [Upstream repository](https://github.com/arviz-devs/arviz/tree/v0.23.4)
- [Upstream changelog/diff](https://github.com/arviz-devs/arviz/compare/v0.22.0...v0.23.4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/pymc-feedstock/pull/7

### Explanation of changes:

- Bump version and SHA
- Add missing dependencies ( setuptools not listed explicitly, but is needed. It was relying on packaging to provide it)


### Note
- There is a v1 available, but this is the version needed for pymc


[PKG-13781]: https://anaconda.atlassian.net/browse/PKG-13781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ